### PR TITLE
chore: remove versions from deps so that the latest one is installed

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-nltk==3.4.5
-pandas==1.0.5
+nltk
+pandas


### PR DESCRIPTION
The dependencies were pinned to versions that were more than 2 years old. I removed the versions so that the latest one is installed.